### PR TITLE
Editando la imagen creando canvas

### DIFF
--- a/src/app/presentation/components/chats-bubbles/gptMessageEditableImage/gptMessageEditableImage.component.html
+++ b/src/app/presentation/components/chats-bubbles/gptMessageEditableImage/gptMessageEditableImage.component.html
@@ -5,14 +5,24 @@
         </div>
         <div class="relative ml-3 text-ms bg-black bg-opacity-25 pt-3 pb-2 px-4 shadow rounded-xl">
 
-            <img 
+            <!-- <img 
                 [src]="imageInfo.url" 
                 [alt]="imageInfo.alt" 
                 class="object-cover rounded-xl"
                 width="1024"
                 height="1024"
                 (click)="handleClick()"
-            />
+            /> -->
+            <canvas
+                width="1024"
+                height="1024"
+                #canvas
+                (mousedown)="onMouseDown($event)"
+                (mousemove)="onMouseMove($event)"
+                (mouseup)="onMouseUp()"
+            >
+
+            </canvas>
 
         </div>
     </div>

--- a/src/app/presentation/components/chats-bubbles/gptMessageEditableImage/gptMessageEditableImage.component.ts
+++ b/src/app/presentation/components/chats-bubbles/gptMessageEditableImage/gptMessageEditableImage.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, Output, signal, ViewChild } from '@angular/core';
+import { isFormControl } from '@angular/forms';
 
 @Component({
   selector: 'app-gpt-message-editable-image',
@@ -10,12 +11,72 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
   templateUrl: './gptMessageEditableImage.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class GptMessageEditableImageComponent { 
-
+export class GptMessageEditableImageComponent implements AfterViewInit {
+  
   @Input({ required: true }) text!: string;
   @Input({ required: true }) imageInfo!: { url: string, alt: string };
-
+  @ViewChild('canvas') canvasElement!: ElementRef<HTMLCanvasElement>;
+  
   @Output() onSelectImage = new EventEmitter<string>();
+
+  public originalImage = signal<HTMLImageElement | null>( null );
+  public isDrawing = signal<boolean>( false );
+  public cords = signal<{ x: number, y: number }>({ x: 0, y: 0 });
+  
+  ngAfterViewInit(): void {
+    isFormControl( !this.canvasElement.nativeElement );
+    const canvas  = this.canvasElement.nativeElement;
+    const context = canvas.getContext('2d');
+    const image = new Image();
+    
+    image.crossOrigin = 'Anonymous';
+    image.src = this.imageInfo.url;
+    this.originalImage.set( image );
+
+    image.onload = () => {
+        if (context) {
+            context.drawImage(image, 0, 0, canvas.width, canvas.height);
+        }
+    }
+  }
+
+  onMouseDown(event: MouseEvent) {
+    if(!this.canvasElement) return;
+    this.isDrawing.set( true );
+    const startX = event.clientX - this.canvasElement.nativeElement.getBoundingClientRect().left; 
+    const startY = event.clientY - this.canvasElement.nativeElement.getBoundingClientRect().top;
+    this.cords.set({ x: startX, y: startY });
+  }
+
+  onMouseMove(event: MouseEvent) {
+    if( !this.isDrawing() || !this.canvasElement.nativeElement ) return;
+    const canvasRef = this.canvasElement.nativeElement;
+    const currentX = event.clientX - canvasRef.getBoundingClientRect().left; 
+    const currentY = event.clientY - canvasRef.getBoundingClientRect().top;
+
+    const width = currentX -this.cords().x;
+    const height = currentY - this.cords().y;
+
+    const canvasWidth = canvasRef.width;
+    const canvasHeight = canvasRef.height;
+    const context = canvasRef.getContext('2d')!;
+    
+    context.clearRect(0, 0, canvasWidth, canvasHeight);
+    
+    context.drawImage(this.originalImage()!, 0, 0, canvasWidth, canvasHeight);
+
+    //context.fillRect(this.cords().x, this.cords().y, width, height);
+    context.clearRect(this.cords().x, this.cords().y, width, height);
+
+  }
+
+  onMouseUp() {
+    this.isDrawing.set( false );
+    const canvas = this.canvasElement.nativeElement;
+    const url = canvas.toDataURL('image/png');
+
+    this.onSelectImage.emit( url );
+  }
 
   handleClick(){
     this.onSelectImage.emit( this.imageInfo.url );

--- a/src/app/presentation/pages/imageTunningPage/imageTunningPage.component.ts
+++ b/src/app/presentation/pages/imageTunningPage/imageTunningPage.component.ts
@@ -27,26 +27,28 @@ import { OpenAiService } from 'app/presentation/services/openai.service';
 export default class ImageTunningPageComponent { 
 
   public messages = signal<MessageInterface[]>([
-    {
+    /* {
       isGpt: true,
       text: 'Dummy Image',
       imageInfo: {
         url: 'http://localhost:3000/gpt/image-generation/1757125575780.png',
         alt: 'Un gato con gafas de sol y una camisa hawaiana, sentado en una playa tropical con palmeras y un mar azul de fondo.',
       }
-    }
+    } */
   ]);
     public isLoading = signal(false);
     public openAiService = inject( OpenAiService );
 
     public originalImage = signal<string | undefined>( undefined );
-  
-    handleMessage(prompt: string) {
+
+    public maskImage = signal<string | undefined>( undefined );
+
+  handleMessage(prompt: string) {
   
     this.isLoading.set(true);
     this.messages.update( (prev) => ([...prev, { isGpt: false, text: prompt }]) );
 
-    this.openAiService.imageGeneration( prompt )
+    this.openAiService.imageGeneration( prompt, this.originalImage(), this.maskImage() )
       .subscribe(resp =>{
         this.isLoading.set(false);
         if( !resp ) return;
@@ -62,7 +64,8 @@ export default class ImageTunningPageComponent {
 
   handleImageChange(newImage: string, originalImage: string){
     this.originalImage.set( originalImage );
-    this.isLoading.set(true);
+    this.maskImage.set( newImage );
+    
     
 
   }


### PR DESCRIPTION
La función de edición interactiva de imágenes de `GptMessageEditableImageComponent` reemplaza la visualización estática de la imagen con un elemento canvas que admite operaciones de dibujo y enmascaramiento. También actualiza `ImageTunningPageComponent` para gestionar los nuevos datos de la imagen de máscara, lo que permite solicitudes de generación de imágenes tanto con la imagen original como con la de máscara.

**Edición interactiva de imágenes y enmascaramiento:**

* Se reemplazó el elemento `<img>` por `<canvas>` en `gptMessageEditableImage.component.html`, lo que permite dibujar y enmascarar directamente la imagen. Ahora se utilizan eventos del ratón para definir regiones de máscara en el lienzo.
* Se implementó la lógica de dibujo y enmascaramiento del lienzo en `GptMessageEditableImageComponent`. Esto incluye el seguimiento de los eventos del ratón, la representación de la imagen original y la emisión de la imagen enmascarada como una URL de datos al finalizar el dibujo.
* Se añadió la gestión del estado de la imagen original, el estado del dibujo y las coordenadas mediante señales angulares.

**Integración con el flujo de generación de imágenes:**

* Se actualizó `ImageTunningPageComponent` para almacenar tanto la imagen original como la imagen de máscara generada, y para pasar ambas a la API `imageGeneration`. [[1]](diffhunk://#diff-f70988e053d33323c476c16924f12874a114bc4832f2120ec0617811dee14169L30-R51) [[2]](diffhunk://#diff-f70988e053d33323c476c16924f12874a114bc4832f2120ec0617811dee14169L65-R68)

**Refactorización y limpieza:**

* Se eliminaron datos de mensajes ficticios no utilizados del estado inicial en `ImageTunningPageComponent`.